### PR TITLE
Correctly handle multiple profiles

### DIFF
--- a/bookmarks.py
+++ b/bookmarks.py
@@ -38,11 +38,19 @@ class FirefoxBookMarks:
         # Read Firefox profiles configuration file to get the database file path.
         profile = __import__("configparser").RawConfigParser()
         profile.read(Path.joinpath(firefox_path, "profiles.ini"))
+        profile_in_use = None
+        for p in profile.sections():
+            if p["Default"]:
+                profile_in_use = p["Default"]
+                break
+
+        if not profile_in_use:
+            profile_in_use = profile.get("Profile0", "Path")
 
         # Sqlite db directory path
         return str(
             Path.joinpath(
-                Path.joinpath(firefox_path, profile.get("Profile0", "Path")),
+                Path.joinpath(firefox_path, profile_in_use),
                 "places.sqlite",
             )
         )

--- a/bookmarks.py
+++ b/bookmarks.py
@@ -39,16 +39,37 @@ class FirefoxBookMarks:
         profile = __import__("configparser").RawConfigParser()
         profile.read(Path.joinpath(firefox_path, "profiles.ini"))
         profile_in_use = None
+        # TODO config file
         for p in profile.sections():
             try:
                 suffix = profile[p]["Default"].split(".")[1]
                 if "dev" not in suffix and "esr" not in suffix:
-                profile_in_use = profile[p]["Default"]
-                break
+                    release = profile[p]["Default"]
+                    break
+                else:
+                    esr_dev = profile[p]["Default"]
             except KeyError:
-                pass
-
-        if not profile_in_use:
+                try:
+                    suffix = profile[p]["Path"].split(".")[1]
+                    if "defaults-release" in suffix:
+                        default_release = profile[p]["Path"]
+                    if "defaults-esr" in suffix:
+                        default_esr = profile[p]["Path"]
+                    if "dev-edition-default" in suffix:
+                        default_dev = profile[p]["Path"]
+                except KeyError:
+                    pass
+        if release:
+            profile_in_use = release
+        elif esr_dev:
+            profile_in_use = esr_dev
+        elif default_release:
+            profile_in_use = default_release
+        elif default_esr:
+            profile_in_use = default_esr
+        elif default_dev:
+            profile_in_use = default_dev
+        else:
             profile_in_use = profile.get("Profile0", "Path")
 
         # Sqlite db directory path

--- a/bookmarks.py
+++ b/bookmarks.py
@@ -40,9 +40,11 @@ class FirefoxBookMarks:
         profile.read(Path.joinpath(firefox_path, "profiles.ini"))
         profile_in_use = None
         for p in profile.sections():
-            if p["Default"]:
-                profile_in_use = p["Default"]
+            try:
+                profile_in_use = profile[p]["Default"]
                 break
+            except KeyError:
+                pass
 
         if not profile_in_use:
             profile_in_use = profile.get("Profile0", "Path")

--- a/bookmarks.py
+++ b/bookmarks.py
@@ -41,6 +41,8 @@ class FirefoxBookMarks:
         profile_in_use = None
         for p in profile.sections():
             try:
+                suffix = profile[p]["Default"].split(".")[1]
+                if "dev" not in suffix and "esr" not in suffix:
                 profile_in_use = profile[p]["Default"]
                 break
             except KeyError:


### PR DESCRIPTION
Check for the default profile, and only use `Profile0` as a fallback.